### PR TITLE
Updated project dependencies

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,9 +3,9 @@
   :url "http://example.com/FIXME"
   :dependencies [[org.clojure/clojure "1.4.0"]
                  [compojure "1.1.3"]
-                 [com.cemerick/friend "0.1.2"]
+                 [com.cemerick/friend "0.1.3"]
                  [ring "1.1.3"]]
-  :plugins [[lein-ring "0.7.5"]]
+  :plugins [[lein-ring "0.8.5"]]
   :ring {:handler friend-form-login.handler/app}
   :profiles
   {:dev {:dependencies [[ring-mock "0.1.3"]]}})


### PR DESCRIPTION
Project dependencies were broken - guice requirement in friend 0.1.2 unavailable, and several broken things in lein-ring 0.7.5. I've updated them in my local copy and this set currently works.
